### PR TITLE
[Feat] 포트폴리오 입력 및 수정 시 화면에서 보여주는 정보 보여주는 api작성

### DIFF
--- a/src/main/java/kwangwoon/chambit/dontworry/domain/portfolio/api/PortfolioController.java
+++ b/src/main/java/kwangwoon/chambit/dontworry/domain/portfolio/api/PortfolioController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kwangwoon.chambit.dontworry.domain.portfolio.dto.request.PortfolioDeleteDto;
 import kwangwoon.chambit.dontworry.domain.portfolio.dto.request.PortfolioInsertDto;
 import kwangwoon.chambit.dontworry.domain.portfolio.dto.request.PortfolioUpdateDto;
+import kwangwoon.chambit.dontworry.domain.portfolio.dto.response.InsertUpdateResponseDto;
 import kwangwoon.chambit.dontworry.domain.portfolio.service.PortfolioService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,16 +62,16 @@ public class PortfolioController {
     @PostMapping()
     @Operation(summary = "포트폴리오 입력", description = "토큰 정보 필요함")
     public ResponseEntity<?> insertPortfolio(@RequestBody PortfolioInsertDto portfolioInsertDto, @AuthenticationPrincipal UserDetails userDetails){
-        portfolioService.insertPortfolio(portfolioInsertDto, userDetails);
-        return ResponseEntity.ok("success");
+        InsertUpdateResponseDto insertUpdateResponseDto = portfolioService.insertPortfolio(portfolioInsertDto, userDetails);
+        return ResponseEntity.ok(insertUpdateResponseDto);
     }
 
 
     @PutMapping("/{portfolioId}")
     @Operation(summary = "포트폴리오 수정")
     public ResponseEntity<?> modifyPortfolio(@PathVariable("portfolioId") Long id, @RequestBody PortfolioUpdateDto portfolioUpdateDto){
-        portfolioService.updatePortfolio(id, portfolioUpdateDto);
-        return ResponseEntity.ok("success");
+        InsertUpdateResponseDto insertUpdateResponseDto = portfolioService.updatePortfolio(id, portfolioUpdateDto);
+        return ResponseEntity.ok(insertUpdateResponseDto);
     }
 
     @DeleteMapping()

--- a/src/main/java/kwangwoon/chambit/dontworry/domain/portfolio/dto/response/InsertUpdateResponseDto.java
+++ b/src/main/java/kwangwoon/chambit/dontworry/domain/portfolio/dto/response/InsertUpdateResponseDto.java
@@ -1,0 +1,30 @@
+package kwangwoon.chambit.dontworry.domain.portfolio.dto.response;
+
+import kwangwoon.chambit.dontworry.domain.portfolio.domain.Portfolio;
+import kwangwoon.chambit.dontworry.domain.stock.domain.Stock;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class InsertUpdateResponseDto {
+    private Long stockId;
+    private String stockName;
+    private Long stockQuantity;
+    private String stockImage;
+    private Long presentPrice;
+    private Long purchasePrice;
+    private Long profit;
+    private Float profitRate;
+
+    @Builder
+    public InsertUpdateResponseDto(Stock stock, Long stockQuantity, Long presentPrice, Long purchasePrice){
+        this.stockId = stock.getId();
+        this.stockName = stock.getStockName();
+        this.stockQuantity = stockQuantity;
+        this.stockImage = stock.getImageUrl();
+        this.presentPrice = presentPrice * stockQuantity;
+        this.purchasePrice = purchasePrice * stockQuantity;
+        this.profit = this.presentPrice - this.purchasePrice;
+        this.profitRate = (float) this.profit / this.purchasePrice * 100;
+    }
+}

--- a/src/main/java/kwangwoon/chambit/dontworry/global/infra/redis/stockPrice/PresentStockPriceService.java
+++ b/src/main/java/kwangwoon/chambit/dontworry/global/infra/redis/stockPrice/PresentStockPriceService.java
@@ -3,15 +3,10 @@ package kwangwoon.chambit.dontworry.global.infra.redis.stockPrice;
 import kwangwoon.chambit.dontworry.domain.portfolio.domain.Portfolio;
 import kwangwoon.chambit.dontworry.domain.stock.domain.Stock;
 import lombok.RequiredArgsConstructor;
-import org.springframework.aop.scope.ScopedProxyUtils;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,7 +14,7 @@ import java.util.stream.Collectors;
 public class PresentStockPriceService {
     private final StringRedisTemplate template;
 
-    public List<Long> getPresentStockPrice(List<Portfolio> portfolios){
+    public List<Long> getPresentStockPrices(List<Portfolio> portfolios){
         List<String> stockCodes = portfolios.stream()
                 .map(x -> {
                     Stock stock = x.getStock();
@@ -30,5 +25,14 @@ public class PresentStockPriceService {
         return template.opsForValue().multiGet(stockCodes).stream()
                 .map(price -> price == null ? -1L : Long.parseLong(price))
                 .collect(Collectors.toList());
+    }
+
+    public Long getPresentStockPrice(String stockCode){
+        String price = template.opsForValue().get(stockCode);
+        if(price == null){
+            return -1L;
+        }else{
+            return Long.parseLong(price);
+        }
     }
 }

--- a/src/test/java/kwangwoon/chambit/dontworry/global/infra/redis/stockPrice/StockPriceServiceTest.java
+++ b/src/test/java/kwangwoon/chambit/dontworry/global/infra/redis/stockPrice/StockPriceServiceTest.java
@@ -4,12 +4,9 @@ import kwangwoon.chambit.dontworry.domain.portfolio.TestDataUtil;
 import kwangwoon.chambit.dontworry.domain.portfolio.domain.Portfolio;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class StockPriceServiceTest {
@@ -22,7 +19,7 @@ class StockPriceServiceTest {
 
 
         List<Portfolio> portfolios = TestDataUtil.getPortfolios();
-        List<Long> presentStocks = stockPriceService.getPresentStockPrice(portfolios);
+        List<Long> presentStocks = stockPriceService.getPresentStockPrices(portfolios);
 
         for(int i=0; i<presentStocks.size(); i++){
             System.out.println("portfolio : " + portfolios.get(i) + " presentPrice : " + presentStocks.get(i));


### PR DESCRIPTION
# Overview
포트폴리오 입력 및 수정 시 화면에서 보여주는 정보 보여주는 api작성
<br/>

# 변경 유형
* [x] 기능 추가
* [x] 리펙토링
* [ ] 버그 수정
* [ ] 성능 개선
* [ ] TC 추가
* [ ] 기타 설정(환경 설정, CI/CD, 문서....)

<br/>

# 수정 내용
1. 실시간 단일 주가 가지고 오는 기능 추가
2. 포트폴리오 수정 및 입력의 응답 값 변경 
3. 이때 새로운 응답 dto생성
<br/>

# 이슈 링크

- closed할 대상의 링크를 적어주세요
- ex) closed #이슈번호
- closed #81 

<br/>

# 레퍼런스